### PR TITLE
Add note about `startAuthentication` native click listener

### DIFF
--- a/docs/advanced/safari-browser.md
+++ b/docs/advanced/safari-browser.md
@@ -4,6 +4,6 @@ title: Safari Browser
 
 When adding support for WebAuthn, special considerations must be made for the Safari browser on both iOS and macOS:
 
-* [@simplewebauthn/browser's `startRegistration()`](packages/browser.mdx#startregistration) must be called in a **native** click listener. Some JS UI libraries, like VueJS, may not use native click handling without the use of framework-specific functionality [like Vue's `.native` modifier](https://vuejs.org/v2/guide/components-custom-events.html#Binding-Native-Events-to-Components).
+* [@simplewebauthn/browser's `startRegistration()`](packages/browser.mdx#startregistration) and [`startAuthentication`](packages/browser.mdx#startauthentication) must be called in a **native** click listener. Some JS UI libraries, like VueJS, may not use native click handling without the use of framework-specific functionality [like Vue's `.native` modifier](https://vuejs.org/v2/guide/components-custom-events.html#Binding-Native-Events-to-Components).
 * ~~Safari only supports the use of XHR and `fetch` within click handlers for requesting WebAuthn registration and authentication options.~~ (Fixed as of February 2021. See [here](https://bugs.webkit.org/show_bug.cgi?id=213595))
 * ~~Not all browsers on iOS or macOS support Touch ID or Face ID. Check [Supported Devices](advanced/supported-devices.md) for more information on which iOS and macOS browsers support which Apple-specific hardware authenticator.~~ (Fixed as of iOS 14.5. See [here](https://twitter.com/IAmKale/status/1386795055856308229))


### PR DESCRIPTION
It looks like in macOS Safari 16.4 the `startAuthentication` call fails if not called within a native click listener. Warning from Safari:

`[Warning] User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events. (906-8c2ba54170f8139a.js, line 1)`
