### PR TITLE
refactor: Renames publicKey to credentialPublicKey

### DIFF
--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -60,7 +60,7 @@ type Passkey = {
   // SQL: Store as `TEXT`. Index this column
   id: Base64URLString;
   // SQL: Store raw bytes as `BYTEA`/`BLOB`/etc...
-  publicKey: Uint8Array;
+  credentialPublicKey: Uint8Array;
   // SQL: Foreign Key to an instance of your internal user model
   user: UserModel;
   // SQL: Store as `TEXT`. Index this column. A UNIQUE constraint on (webAuthnUserID + user) also

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -270,7 +270,7 @@ const newPasskey: Passkey = {
   // A unique identifier for the credential
   id: credentialID,
   // The public key bytes, used for subsequent authentication signature verification
-  publicKey: credentialPublicKey,
+  credentialPublicKey: Array.from(credentialPublicKey),
   // The number of times the authenticator has been used on this site so far
   counter,
   // Whether the passkey is single-device or multi-device


### PR DESCRIPTION
This PR makes the following changes:
* Renames `publicKey` to  `credentialPublicKey` because [it's expected by VerifySignature](https://github.com/MasterKale/SimpleWebAuthn/blob/b299b51a0b4cd2731aa4ee2e5644ee13bab9843f/packages/server/src/authentication/verifyAuthenticationResponse.ts#L243)
* Converts `Uint8Array` to `Array` for easy storage in a DB