### PR TITLE
Fix "Error: no data" troubleshooting

### DIFF
--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -564,9 +564,9 @@ To fix this, massage the `Binary` public key bytes into an instance of `Uint8Arr
 ```js
 const verification = await verifyAuthenticationResponse({
   // ...
-  authenticator: {
+  credential: {
     // ...
-    credentialPublicKey: new Uint8Array(credentialPublicKey.buffer),
+    publicKey: new Uint8Array(credentialPublicKey.buffer),
   },
 });
 ```


### PR DESCRIPTION
The "Error: no data" troubleshooting section points to "authenticator.credentialPublicKey", but that seems to be outdated and changed to "credential.publicKey".